### PR TITLE
set up for javadoc extension in javadoc module, add to nav

### DIFF
--- a/docs/antora.yml
+++ b/docs/antora.yml
@@ -7,10 +7,6 @@ prerelease: -SNAPSHOT
 nav:
 - modules/ROOT/nav.adoc
 
-javadoc:
-  sources:
-    - url: https://oss.sonatype.org/content/repositories/snapshots/dev/morphia/morphia/morphia-core/2.2.0-SNAPSHOT/morphia-core-2.2.0-20201118.035313-3-javadoc.jar
-
 asciidoc:
   attributes:
     branch: master
@@ -21,3 +17,7 @@ asciidoc:
     docsRef: http://docs.mongodb.org/manual
     srcRef: https://github.com/MorphiaOrg/morphia/blob/master
 
+javadoc:
+  sources:
+    - url: https://oss.sonatype.org/content/repositories/snapshots/dev/morphia/morphia/morphia-core/2.2.0-SNAPSHOT/morphia-core-2.2.0-20201118.035313-3-javadoc.jar
+      module: javadoc

--- a/docs/modules/ROOT/nav.adoc
+++ b/docs/modules/ROOT/nav.adoc
@@ -2,3 +2,4 @@
 * xref:quicktour.adoc[Quick Tour]
 * xref:reference.adoc[Reference]
 * xref:issues-help.adoc[Issues & Support]
+* xref:javadoc:index.html#[Javadoc]


### PR DESCRIPTION
This (finishes) configuring the javadoc extension, putting the javadoc in the 'javadoc' module rather  than ROOT. 

I also added a nav entry so you could get to the javadoc easily :-).

It looks ok although I think the drop-down in the header doesn't work quite right yet, probably a css problem between Antora and Oracle/javadoc.